### PR TITLE
don't emit emtpy version; make check/get/put consitent version wise

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -24,6 +24,5 @@ fi
 [ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
 # Consider the most recent LastModified timestamp as the most recent version.
-timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$prefix" --query 'Contents[].{LastModified: LastModified}')
-recent="$(echo $timestamps | jq -r 'max_by(.LastModified)')"
+recent="$("$(dirname $0)/get_version.sh" "$bucket" "$prefix")"
 echo "[$recent]"

--- a/assets/emit.sh
+++ b/assets/emit.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-set -e
-
-# give back a(n empty) version, so that the check passes when using `in`/`out`
-echo "{
-  \"version\": {}
-}"

--- a/assets/get_version.sh
+++ b/assets/get_version.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Outputs the most recent version object: {"LastModified": "..."}
+# Prints nothing when no objects exist under the prefix.
+
+set -e
+
+bucket=$1
+prefix=$2
+
+aws s3api list-objects \
+  --bucket "$bucket" \
+  --prefix "$prefix" \
+  --query 'Contents[].{LastModified: LastModified}' \
+| jq -c 'if length == 0 then empty else max_by(.LastModified) end'

--- a/assets/in
+++ b/assets/in
@@ -41,4 +41,5 @@ if [ "$dosync" == "true" ]; then
   echo "...done."
 fi
 
-source "$(dirname $0)/emit.sh" >&3
+version=$(echo "$payload" | jq -c '.version')
+echo "{\"version\": $version}" >&3

--- a/assets/out
+++ b/assets/out
@@ -42,4 +42,5 @@ echo "Running: aws s3 cp $source/$dir \"s3://$bucket/$path\" $options"
 eval aws s3 cp $source/$dir "s3://$bucket/$path" $options $put_options
 echo "...done."
 
-source "$(dirname $0)/emit.sh" >&3
+recent="$("$(dirname $0)/get_version.sh" "$bucket" "$path")"
+echo "{\"version\": $recent}" >&3


### PR DESCRIPTION
don't emit emtpy version; make check/get/put consitent version wise

- Concourse v8.X doesn't allow emitting the empty version: https://github.com/concourse/concourse/pull/9293