### PR TITLE
ci: set check_every: never on s3-resource-simple resource type

### DIFF
--- a/ci/pipelines/s3-resource-simple-template.yml
+++ b/ci/pipelines/s3-resource-simple-template.yml
@@ -43,7 +43,17 @@ resource_types:
 
 - name: s3-resource-simple
   type: registry-image
-  check_every: 24h
+  # This is a resource type image that we build and push to our registry from the same pipeline and
+  # at the same time we need to run the tests using the same resource type image we just built.
+  # We must ensure that the same image digest that we just built is used in tests. This is impossible
+  # to explicitly configure from the pipeline perspective, because we don't much control over the version
+  # of the resource type. Concourse will schedule the check and get for the resource type on its own.
+  # Even putting check_every to a very small value, the risk of the race condition is still there. The only
+  # viable workaround so far is to set check_every to never. This will trigger the check ALWAYS. 
+  # NOTE that we are still not 100% safe from the race condition, because if another build pushes the new digest
+  # while our test jobs are waiting for the worker, we can still use the wrong digest. Sadly, this is the best
+  # we can do.
+  check_every: never
   source:
     <<: *docker-registry-config
     repository: docker.ci.pix4d.com/s3-resource-simple


### PR DESCRIPTION
ci: fix/improve the pipeline race

:exploding_head: :exploding_head: :exploding_head: 
:exploding_head: :exploding_head: :exploding_head: 
:exploding_head: :exploding_head: :exploding_head: 

**My humble opinion: I hate this pipeline** 

**The problem:**

In the same pipeline, we first built the Docker image that is used in the same pipeline to test the behaviour of **the resource type** we just built. We can't actually pin the Docker image (the digest of it), only tag it, because Concourse registry-image works with tags, not digests + we don't know the digest of the image that we will built in the pipeline at pipeline creation time.

**How to identify it?**
In  `put:bucket.s3simple` the `get:s3-resource-simple` will fail with: ` GET https://docker.ci.pix4d.com/v2/s3-resource-simple/manifests/sha256:ffe766e3c03a70671dc7d0be38bfb4442e8a4528f4ca5b35fc29c59e199b4671: MANIFEST_UNKNOWN: The named manifest is not known to the registry`

<img width="2171" height="489" alt="Screenshot from 2026-07-02 11-46-43" src="https://github.com/user-attachments/assets/f86271ce-36f7-4cb0-bdac-8ea8ac9fafc9" />

OR it will be green but use the WRONG digest for the image, because `check_every: 24h` forced the Concourse to use the cached digest already in memory. It will only check for new digest each 24h.
 
**What we want?**

We want that the digest of the docker image built in `build` job and pushed with `s3-resource-simple.docker` step, matches the digest of the docker image of the resource  type used in `bucket.s3simple` put step in `test-put` job in the build that was triggered from the same commit.

e.g just look at this pipeline

- build 2 of of `build` job was running for commit: `06aa891269a41c6a9468ceaac5530b04554a573a` and produced and pushed a docker image with digest `f49d73d1363e2e8b8c46a52aa80e5ff6c82b2cfdd24801bb2c645ad75476dd40`
https://builder.ci.pix4d.com/teams/developers/pipelines/s3-resource-simple-pci-4876-add-metadata/jobs/build/builds/2
<img width="2175" height="344" alt="Screenshot from 2026-07-02 11-38-55" src="https://github.com/user-attachments/assets/e2ca8f5e-3e04-422c-990c-8cb54073f892" />
- then build 1 of `test-put` job was triggered (passed constraint on git resource)
https://builder.ci.pix4d.com/teams/developers/pipelines/s3-resource-simple-pci-4876-add-metadata/jobs/test-put/builds/1
so we are guaranteed that commit: `06aa891269a41c6a9468ceaac5530b04554a573a`  matches, but there is nothing in our pipeline configuration that guarantees us that digest `f49d73d1363e2e8b8c46a52aa80e5ff6c82b2cfdd24801bb2c645ad75476dd40` will be used in `bucket.s3simple` put step. 
<img width="2146" height="927" alt="Screenshot from 2026-07-02 11-40-50" src="https://github.com/user-attachments/assets/5827f707-0cb7-4058-b335-8a4c67375571" />

Why? because Concourse will first trigger a check to find the new versions (digests) of the docker image used in 23-simple resource type; fetch it and then use it. It can find anything. With check_every: never we are garantueed a check will be done, but we are not guaranteed the digest/version of it; e.g if build job already published another image, while our job was waiting for a worker, we will pick up the new digest. At least the digest will always be there.

**Did this ever work?**
1. with <= v7.X: **probably not**
2. before OPA with default check_every: 7m: **probably not**

The problem is just hidden; on first built in feature pipeline it always work correctly, in master pipeline or subsequent builds in feature pipeline it always works incorrectly, even if the build is green. This repo is never active enough to notice it. Even in feature pipelines, we barely ever had multiple commits; or builds to notice.

**Why was the master pipeline mostly green in the past? and apparently using correct digests?**
We use only 1 tag: latest in all pipelines; and we used global resources; we were lucky enough that in the time after we pushed the new digest in build job, we have a delay until the test-put starts using the s3-simple-resource type of a cca >=1min; many other pipelines were using the same resource, so at least 1 of them did a check for it, before our test-put started to use the image. This is easily seen, because the check step never selects the worker; always uses the in memory value.
