### PR TITLE
out script: we MUST emit a version even when we don't upload anything

### DIFF
--- a/assets/get_version.sh
+++ b/assets/get_version.sh
@@ -12,4 +12,4 @@ aws s3api list-objects \
   --bucket "$bucket" \
   --prefix "$prefix" \
   --query 'Contents[].{LastModified: LastModified}' \
-| jq -c 'if length == 0 then empty else max_by(.LastModified) end'
+| jq -c 'if . == null or length == 0 then empty else max_by(.LastModified) end'

--- a/assets/out
+++ b/assets/out
@@ -43,4 +43,8 @@ eval aws s3 cp $source/$dir "s3://$bucket/$path" $options $put_options
 echo "...done."
 
 recent="$("$(dirname $0)/get_version.sh" "$bucket" "$path")"
-echo "{\"version\": $recent}" >&3
+if [ -z "$recent" ]; then
+  echo "warning: no files were uploaded to s3://$bucket/$path (dir=$dir did not contained any files); emitting synthetic version timestamp" >&2
+  recent="$(jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" '{LastModified: $ts}')"
+fi
+echo "$recent" | jq -c '{version: .}' >&3


### PR DESCRIPTION
out script: we MUST emit a version even when we don't upload anything

Fix out script when no files are uploaded

